### PR TITLE
Fix compilation with FABLE_COMPILER constant

### DIFF
--- a/src/Plough.WebApi.Core/ClientBuilder.fs
+++ b/src/Plough.WebApi.Core/ClientBuilder.fs
@@ -52,7 +52,7 @@ type ClientBuilder(init : ClientBuilderInit) =
         #if FABLE_COMPILER
         inline
         #endif
-        x.GetBinary(relativeUrl:string) : TaskEither<byte []>  =
+        x.GetBinary(relativeUrl:string) =
             let url = Url.combine x.BaseUrl relativeUrl
             x.Client.GetBinary(url)
         


### PR DESCRIPTION
I'm trying to speed up Fable builds by precompiling sources from packages and common sources. For this, I need to generate a .dll with the precompiled files that can be referenced in the next compilations. However when trying to do this, the F# compiler gives me some errors. The errors can be reproduced by trying to build Plough.WebApi.Core with the `FABLE_COMPILER` constant and the changes in this PR should fix them.

> Not entirely sure why the errors didn't appear in "normal" Fable compilation though.