### PR TITLE
Make ServerBuilder.errorHandler abstract to allow customization.

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -68,3 +68,6 @@
 
 ## New in 1.2.1 (Released 2022/07/21)
 * [Revert Plough.ControlFlow, undo native F# task support](https://github.com/demetrixbio/Plough.WebApi/pull/5)
+
+## New in 1.2.2 (Released 2022/08/29)
+* Allow customizable error handling by making ServerBuilder.errorHandler abstract

--- a/src/Plough.WebApi.Server.Giraffe/ServerBuilder.fs
+++ b/src/Plough.WebApi.Server.Giraffe/ServerBuilder.fs
@@ -10,8 +10,9 @@ open Giraffe.Routing
 open Thoth.Json.Net
 
 type ServerBuilder() =
+    abstract errorHandler : failure: FailureMessage -> next : HttpFunc -> ctx : HttpContext -> HttpFuncResult
     
-    member x.errorHandler failure next ctx  =
+    default x.errorHandler failure next ctx  =
         let problem = ProblemReport.failureToProblemReport failure
         let serializedProblem = Encode.Auto.toString(4, problem)
         let errorResponse = clearResponse


### PR DESCRIPTION
Makes the `errorHandler` method abstract so inheriting clients can customize this behavior.